### PR TITLE
Fix 'unkown type: float' in Swagger

### DIFF
--- a/lib/maru_swagger/params_extractor.ex
+++ b/lib/maru_swagger/params_extractor.ex
@@ -50,6 +50,10 @@ defmodule MaruSwagger.ParamsExtractor do
       {param.param_key, do_format_param(param.type, param)}
     end
 
+    defp do_format_param("float", param) do
+      %{type: "number", format: "float", description: param.desc || "", required: param.required}
+    end
+
     defp do_format_param("map", param) do
       %{type: "object", properties: param.children |> Enum.map(&format_param/1) |> Enum.into(%{})}
     end


### PR DESCRIPTION
The `Float` float type is not supported by Swagger. According to the [Swagger specification](https://swagger.io/docs/specification/data-models/data-types/#numbers), a parameter of type `Float` should be specified as either `number` or `number :: float`.